### PR TITLE
Filter case of EXTRACT function

### DIFF
--- a/sql2mermaid/main.py
+++ b/sql2mermaid/main.py
@@ -39,7 +39,7 @@ def analyze_query(query: str, root_name: str) -> Tuple[Tables, Dependencies]:
             table_name = remove_quotes(token.value)
             tables.add(table_name)
             current_table = table_name
-        elif token.ttype is sqlparse.tokens.Keyword and is_pre_tables_mark(token.value):  # FROM or JOIN
+        elif token.ttype is sqlparse.tokens.Keyword and is_pre_tables_mark(token.value, parsed[i - 3].value):  # FROM or JOIN
             table_name = remove_quotes(parsed[i + 1].value)
             if not table_name == "(":
                 tables.add(table_name)

--- a/sql2mermaid/utils.py
+++ b/sql2mermaid/utils.py
@@ -1,5 +1,5 @@
-def is_pre_tables_mark(x: str) -> bool:
-    if x.upper() == "FROM":
+def is_pre_tables_mark(x: str, y: str) -> bool:
+    if x.upper() == "FROM" and not y.upper() == "EXTRACT":
         return True
     elif "JOIN" in x.upper():
         return True

--- a/tests/case_with_extract/expected.txt
+++ b/tests/case_with_extract/expected.txt
@@ -1,0 +1,9 @@
+graph LR
+
+salesData([salesData])
+root([root])
+
+sales[(sales)]
+
+salesData --> sales
+root --> salesData

--- a/tests/case_with_extract/query.sql
+++ b/tests/case_with_extract/query.sql
@@ -1,0 +1,13 @@
+with
+    salesData as (
+        select
+            extract(year from saleDate) as saleYear
+            product
+        from
+            sales
+    )
+select
+    saleYear,
+    product
+from
+    salesData;

--- a/tests/test_sql2mermaid.py
+++ b/tests/test_sql2mermaid.py
@@ -13,6 +13,7 @@ parent = Path(__file__).parent
         ("simple_case"),
         ("normal_case"),
         ("complex_case"),
+        ("case_with_extract"),
     ],
 )
 def test_convert(test_case: Path) -> None:


### PR DESCRIPTION
I tried your module and could not parse SQLs such as `EXTRACT (YEAR FROM date_column) AS YEAR_COLUMN` properly.
This is because the code regard the next token of `FROM` as the table name without other conditions.

I added a condition to filter out cases where there is EXTRACT before FROM. And also test cases.

I know this is not a beautiful and comprehensive solution, so please regard this pull request as only a suggestion to improve the library. 